### PR TITLE
Update PkgConfig to Version 1.5.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,8 @@ source:
 
 build:
   number: 0
+  # skip s390x due to missing the package poetry for the s390x architecture
+  skip: True  # [py<36 or s390x]
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
@@ -22,7 +24,7 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python
+    - python >=3.6
     - pkg-config        # [unix]
     - m2w64-pkg-config  # [win]
 
@@ -31,6 +33,7 @@ test:
     - pkgconfig
     - pkgconfig.pkgconfig
   requires:
+    - python <3.10
     - pip
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,6 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<33]
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,8 +20,6 @@ requirements:
   host:
     - python
     - pip
-    - nose >=1.0
-    - poetry
     - poetry-core >=1.0.0
     - setuptools
     - wheel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
 
 build:
   number: 0
+  skip: true  # [py<33]
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,7 @@ source:
 
 build:
   number: 0
-  # noarch: python
   # skip s390x due to missing the package poetry for the s390x architecture
-  # skip: True  # [py<36 or s390x]
   skip: True  # [s390x]
   script: python -m pip install --no-deps --ignore-installed .
 
@@ -20,7 +18,7 @@ requirements:
   host:
     - python
     - pip
-    - poetry-core >=1.0.0
+    - poetry_core >=1.0.0
     - setuptools
     - wheel
   run:
@@ -33,7 +31,6 @@ test:
     - pkgconfig
     - pkgconfig.pkgconfig
   requires:
-    # - python <3.10
     - pip
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,10 @@ source:
 
 build:
   number: 0
+  # noarch: python
   # skip s390x due to missing the package poetry for the s390x architecture
-  skip: True  # [py<36 or s390x]
+  # skip: True  # [py<36 or s390x]
+  skip: True  # [s390x]
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
@@ -24,7 +26,7 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python >=3.6
+    - python
     - pkg-config        # [unix]
     - m2w64-pkg-config  # [win]
 
@@ -33,7 +35,7 @@ test:
     - pkgconfig
     - pkgconfig.pkgconfig
   requires:
-    - python <3.10
+    # - python <3.10
     - pip
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.5.4" %}
+{% set version = "1.5.5" %}
 
 package:
   name: pkgconfig
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/pkgconfig/pkgconfig-{{ version }}.tar.gz
-  sha256: c34503829fd226822fd93c902b1cf275516908a023a24be0a02ba687f3a00399
+  sha256: deb4163ef11f75b520d822d9505c1f462761b4309b1bb713d08689759ea8b899
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,14 +11,14 @@ source:
 build:
   number: 0
   # skip s390x due to missing the package poetry for the s390x architecture
-  skip: True  # [s390x]
+  # skip: True  # [s390x]
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
   host:
     - python
     - pip
-    - poetry_core >=1.0.0
+    - poetry-core >=1.0.0
     - setuptools
     - wheel
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,6 @@ source:
 
 build:
   number: 0
-  # skip s390x due to missing the package poetry for the s390x architecture
-  # skip: True  # [s390x]
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:


### PR DESCRIPTION
  `pkgconfig` version `1.5.5`
1. check the upstream
   https://github.com/matze/pkgconfig/tree/v1.5.5
2. check the pinnings
    https://github.com/matze/pkgconfig/blob/v1.5.5/tox.ini

    https://github.com/matze/pkgconfig/blob/v1.5.5/test_pkgconfig.py

    https://github.com/matze/pkgconfig/blob/v1.5.5/setup.cfg

    https://github.com/matze/pkgconfig/blob/v1.5.5/pyproject.toml

3. check the changelogs
    https://github.com/matze/pkgconfig/blob/v1.5.5/README.rst

    There were no breaking changes mentioned in the changelog

4. additional research
    https://github.com/conda-forge/pkgconfig-feedstock/issues

    https://github.com/conda-forge/pkgconfig-feedstock/issues/4

    There is one open issue in conda forge about the name of the package. The name of the package is unlikely to change. Because of this we can mostlikely ignore that issue since the maintainers were not interested on making the package name at the time of the review. 

5. verify dev_url
    https://github.com/matze/pkgconfig

6. verify doc_url
    https://github.com/matze/pkgconfig/blob/master/README.rst

7. pip in the test section
8. veriy the test section
9. additional tests

In order to test the `pkgconfig` package version `1.5.5` the folowing
command was used:
`conda build pkgconfig-feedstock --test`
the test result was the following:
`All tests passed`

Based on the research findings and the test results we can conclude
that it is safe to update `pkgconfig` to version `1.5.5`

