### PR TITLE
pkgconfig 1.5.5: rebuild for py314

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+channels:
+  - ad-testing/label/py314
+
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
-channels:
-  - ad-testing/label/py314
-
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: deb4163ef11f75b520d822d9505c1f462761b4309b1bb713d08689759ea8b899
 
 build:
-  number: 0
+  number: 1
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-9225](https://anaconda.atlassian.net/browse/PKG-9225)
- [Upstream repo](https://github.com/matze/pkgconfig/tree/v1.5.5)
- requirements-tagged:
  - https://github.com/matze/pkgconfig/blob/v1.5.5/pyproject.toml
  - https://github.com/matze/pkgconfig/blob/v1.5.5/setup.cfg


### Explanation of changes:

- Bump the build number to 1
- Add `ANACONDA_ROCKET_ENABLE_PY314 : yes` to `abs.yaml`

[PKG-9225]: https://anaconda.atlassian.net/browse/PKG-9225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ